### PR TITLE
Fix a bug when define a grandson type

### DIFF
--- a/eproject.el
+++ b/eproject.el
@@ -367,11 +367,11 @@ what to look for.  Some examples:
 
 (defun eproject--linearized-isa (type &optional include-self)
   (delete-duplicates
-   (nconc
+   (append
     (if include-self (list type))
     (eproject--project-supertypes type)
     (loop for stype in (eproject--project-supertypes type)
-          nconc (eproject--linearized-isa stype)))))
+          append (eproject--linearized-isa stype)))))
 
 (defun eproject--all-types ()
   ;; this should be most specific to least specific, as long as nothing


### PR DESCRIPTION
nanoc leads to infinit loop for grandson types, e.g.

```
(define-project-type generic-bundle (generic-git) (look-for "Gemfile")
  :irrelevant-files ("^[.]" "^[#]" ".git/" "vendor"))
```
