### PR TITLE
require 'etags, otherwise getting error in process sentinel

### DIFF
--- a/contrib/eproject-tags.el
+++ b/contrib/eproject-tags.el
@@ -27,6 +27,7 @@
 (eval-when-compile
   (require 'cl))
 (require 'eproject)
+(require 'etags)
 
 (defvar eproject-tags-etags "etags"
   "The command you want to run to generate the tags file.


### PR DESCRIPTION
error in process sentinel: let: Symbol's function definition is void: tags-verify-table
