### PR TITLE
Allow eproject to work not only with dired-mode, but also with modes derived from it.

### DIFF
--- a/eproject.el
+++ b/eproject.el
@@ -352,7 +352,7 @@ what to look for.  Some examples:
     (otherwise (error "Don't know how to handle %s in LOOK-FOR!" type))))
 
 (defun eproject--buffer-file-name ()
-  (or (buffer-file-name) (and (eq major-mode 'dired-mode)
+  (or (buffer-file-name) (and (derived-mode-p 'dired-mode)
                               (expand-file-name (if (consp dired-directory)
                                                     (car dired-directory)
                                                   dired-directory)))))


### PR DESCRIPTION
See https://github.com/escherdragon/sunrise-commander/issues/9 -- this is an
issue reported by a user of the Sunrise Commander who happens to be also an
eproject user. SC has major mode `sr-mode' which is a mode derived from
dired-mode.
