### PR TITLE
Fixed the end of string in `auto-mode-alist` regexp.

### DIFF
--- a/eproject.el
+++ b/eproject.el
@@ -695,7 +695,7 @@ that FILE is an absolute path."
 
 (add-hook 'eproject-project-change-hook #'eproject--maybe-reinitialize)
 
-(add-to-list 'auto-mode-alist '("\\.eproject$" . dot-eproject-mode))
+(add-to-list 'auto-mode-alist '("\\.eproject\\'" . dot-eproject-mode))
 
 (provide 'eproject)
 ;;; eproject.el ends here


### PR DESCRIPTION
`$` could match a newline whereas `\\'` cannot.
