### PR TITLE
Do not modify global key in helm-eproject.el

### DIFF
--- a/contrib/helm-eproject.el
+++ b/contrib/helm-eproject.el
@@ -88,7 +88,9 @@
   (helm :sources '(helm-eproject-source)
         :buffer "*Helm Eproject*"))
 
-(global-set-key [(control x) (f)] 'helm-eproject) ;;set-fill-column is just useless ;)
+(defun eproject-helm-configure ()
+  "Bind C-x f to `helm-eproject'."
+  (global-set-key [(control x) (f)] 'helm-eproject))
 
 (provide 'helm-eproject)
 


### PR DESCRIPTION
Instead, eproject-helm-configure is added.  User can call this
function when s/he wants to use the original configuration.
