### PR TITLE
Don't treat git submodule as a project root

### DIFF
--- a/eproject.el
+++ b/eproject.el
@@ -320,7 +320,7 @@ become project attributes."
 
 (define-project-type generic-eproject (generic) (look-for ".eproject"))
 
-(define-project-type generic-git (generic) (look-for ".git"))
+(define-project-type generic-git (generic) (look-for ".git/"))
 
 (define-project-type generic-hg (generic) (look-for ".hg"))
 


### PR DESCRIPTION
1. Don't treat linked git repositories such as submodules as project roots. …
   The difference is that there is only a file named .git and not a directory. 
   I do belive that this is the most common thing one would want.
2. Always treat all scm repository meta directories as irrelevant.
   This simplifies the generic type definitions.
