### PR TITLE
Allow user-data to override project name and type

### DIFF
--- a/eproject.el
+++ b/eproject.el
@@ -524,13 +524,12 @@ else through unchanged."
               (eproject--interpret-metadata
                (eproject--eval-user-data name root) root))
 
-             (name-and-type (list :type type :name name))
+             ;; now compute the final list of attributes, allowing user-data
+             ;; to override the name.
+             (data (nconc user-data (list :name name) class-and-config-data)))
 
-             ;; now compute the final list of attributes
-             (data
-              (nconc user-data (nconc name-and-type class-and-config-data))))
-
-        (add-to-list 'eproject-attributes-alist (cons root data))))))
+        (add-to-list 'eproject-attributes-alist
+                     (cons root (nconc (list :type type) data)))))))
 
 (defvar eproject-mode-map (make-sparse-keymap)
   "Keybindings while in eproject-mode")


### PR DESCRIPTION
This allows extensions to define project-attributes that override the project's name and type.

The motivation for this is to allow users to override project name at a project level ( calling it "master", the current branch they are working on or something else) by using define-project-attribute. It creates a level of granularity where you can have a default-value defined in the project-type which is overridden by the project file. The project-file can then in turn be overridden by project-type-instance specific values defined by the user.
