### PR TITLE
Remove generic-git project definition

### DIFF
--- a/eproject.el
+++ b/eproject.el
@@ -320,9 +320,6 @@ become project attributes."
 
 (define-project-type generic-eproject (generic) (look-for ".eproject"))
 
-(define-project-type generic-git (generic) (look-for ".git")
-  :irrelevant-files ("^[.]" "^[#]" ".git/"))
-
 (define-project-type generic-hg (generic) (look-for ".hg")
   :irrelevant-files ("^[.]" "^[#]" ".hg/"))
 


### PR DESCRIPTION
Automatically considering a git repository to be a separate project does not work that well for projects that make use of git submodules.

I do most of my work in a fairly large system where a lot of the libraries live in their own git submodules. While the generic-git project type is defined eproject will always consider the submodule to be its own project and it is not possible to have it as a part of the superproject.

In general I think it would be wizer to not trust the presence of files unrelated to eproject (.git, .bzr etc.) to automatically indicate that something is a project, but I'm unsure of how these other vc systems work.
