### PR TITLE
When visiting an eproject file, run the file-visit-hooks of that buffer's project type's supertypes.

### DIFF
--- a/eproject.el
+++ b/eproject.el
@@ -581,6 +581,8 @@ else through unchanged."
 
       ;; run project-type hooks, which may also call into eproject-*
       ;; functions
+      (mapc (lambda (x) (run-hooks (intern (format "%s-project-file-visit-hook" x))))
+            (eproject--project-supertypes besttype))
       (run-hooks (intern (format "%s-project-file-visit-hook" besttype)))
 
       ;; return the project root; it's occasionally useful for the caller


### PR DESCRIPTION
A small change - run all applicable *-project-file-visit-hooks when visiting a project file instead of just running the hook for the most specific project type.
