### PR TITLE
Magit support

### DIFF
--- a/eproject.el
+++ b/eproject.el
@@ -705,10 +705,8 @@ that FILE is an absolute path."
 (add-hook 'find-file-hook #'eproject-maybe-turn-on)
 (add-hook 'dired-mode-hook #'eproject-maybe-turn-on)
 
-(defun eproject-magit-mode-hook ()
-  (when (derived-mode-p 'magit-status-mode)
-    (eproject-maybe-turn-on)))
-(add-hook 'magit-mode-hook #'eproject-magit-mode-hook)
+(eval-after-load 'magit
+  (add-hook 'magit-status-mode-hook #'eproject-maybe-turn-on))
 
 (add-hook 'after-change-major-mode-hook #'eproject--after-change-major-mode-hook)
 (add-hook 'after-save-hook #'eproject--after-save-hook)


### PR DESCRIPTION
Implementation credit goes to @binarin, but I'm requesting a merge because I find it useful. Admittedly, special-casing magit-status-mode buffers smells a little wrong, but the same thing is done with dired buffers. Ideally, there'd be some macro that provides a generic way to add special case buffers to the tests in  `eproject--buffer-file-name`, but I haven't spent any time on it because this works for me.
