### PR TITLE
Fix cpd shell command for multiple frame session

### DIFF
--- a/contrib/eproject.sh
+++ b/contrib/eproject.sh
@@ -28,7 +28,7 @@
 # Go to currently active project root in Emacs
 cdp() {
     local EMACS_CWP=$(emacsclient -a false -e \
-        "(eproject-print-current-project-working-directory)" \
+        "(eproject-current-working-directory)" \
         | sed 's/^"\(.*\)"$/\1/')
     if [ -d "$EMACS_CWP" ]; then
         cd "$EMACS_CWP"

--- a/eproject-extras.el
+++ b/eproject-extras.el
@@ -337,8 +337,8 @@ With the prefix arg LOOK-IN-INVISIBLE-BUFFERS looks in buffers that are not curr
                                 ;; the window if you want
 
 ;;;###autoload
-(defun eproject-print-current-project-working-directory ()
-  "Print the project root directory for most recently visited
+(defun eproject-current-working-directory ()
+  "Return the project root directory for most recently visited
 buffer.  Fallback to the directory of the buffer when it is
 not in a project."
   (let ((current-buffer (car (frame-parameter nil 'buffer-list))))


### PR DESCRIPTION
When more than two frame is used, buffer in the most recently _created_ (not _visited_) frame is used.
