### PR TITLE
Let projects control arguments passed to the eproject-tags-etags command

### DIFF
--- a/contrib/eproject-tags.el
+++ b/contrib/eproject-tags.el
@@ -58,18 +58,23 @@ Only works with exuberant-ctags; this will cause standard etags to blow up in a 
       (insert "\n"))))
 
 (defun eproject-tags--generate (cb &optional state root)
-  "Generate a tags table for this project (or the project in ROOT), calling CB with the project root and STATE upon completion.
+  "Generate a tags table for this project (or the project in ROOT), calling CB
+  with the project root and STATE upon completion.
 
-All project-relevant files are considered and output goes to root/TAGS.  The tags table is not visited after generation."
+By default the tags command is passed all project-relevant files as arguments. A
+project can instead define a list of files (and other arguments) in the project
+attribute :tags-cmd-args.
+
+Output goes to root/TAGS. The tags table is not visited after generation."
   (let* ((root  (or root (eproject-root)))
          (default-directory root)
-         (files (eproject-list-project-files-relative root))
          (name  (concat (eproject-attribute :name root) "-TAGS"))
          (buf   (eproject-tags--buffer root))
          (args  (append '("-o" ".TAGS-tmp")
-                        (if eproject-tags-verbose '("--verbose"))))
-         (proc  (apply #'start-process name buf eproject-tags-etags
-                       (append args files))))
+                        (if eproject-tags-verbose '("--verbose"))
+                        (or (eproject-attribute :tags-cmd-args root)
+                            (eproject-list-project-files-relative root))))
+         (proc  (apply #'start-process name buf eproject-tags-etags args)))
 
     (with-current-buffer buf
       (setq eproject-tags-callback cb)

--- a/contrib/eproject-tags.el
+++ b/contrib/eproject-tags.el
@@ -62,8 +62,8 @@ Only works with exuberant-ctags; this will cause standard etags to blow up in a 
   with the project root and STATE upon completion.
 
 By default the tags command is passed all project-relevant files as arguments. A
-project can instead define a list of files (and other arguments) in the project
-attribute :tags-cmd-args.
+project can instead return a list of files (and other arguments) in a function
+defined in project attribute :tags-cmd-args.
 
 Output goes to root/TAGS. The tags table is not visited after generation."
   (let* ((root  (or root (eproject-root)))


### PR DESCRIPTION
This commit allows the following:

```
(define-project-type foo (generic)
  (look-for "foo.cfg")
  :tags-cmd-args (lambda (root) '("-R" "--languages=-JavaScript" "my/files")))
```

which - when eproject-tags is called from a foo project - will invoke etags with:

```
etags -o .TAGS-tmp --verbose -R --languages=-JavaScript my/files
```
