### PR TITLE
Add ability to have a func return a compile string

### DIFF
--- a/contrib/eproject-compile.el
+++ b/contrib/eproject-compile.el
@@ -51,10 +51,13 @@
    (let ((potential-compiles (eproject-attribute :common-compiles))
 	 (new-compile-history (list ())))
      (if potential-compiles
-	 (mapcar
-	  '(lambda (c)
-	     (format "cd %s && %s" (eproject-root) c))
-	  potential-compiles)
+	 (delq 'nil (mapcar
+		     '(lambda (c)
+			(cond
+			 ((functionp c) (funcall c (eproject-root)))
+			 ((stringp c) (format "cd %s && %s" (eproject-root) c))
+			 (t 'nil)))
+		     potential-compiles))
        (list (format "cd %s && make -k" (eproject-root)))))))
 
 ;;;###autoload


### PR DESCRIPTION
Sometimes you want something fancier that a simple string for your make
invocations. This way you can define a function in your :common-compiles
list which can return a string or nil. The function is passed the
eproject-root. Any nils are removed from the final list passed back to
the compile history.
