### PR TITLE
Use relative files in helm-eproject

### DIFF
--- a/contrib/helm-eproject.el
+++ b/contrib/helm-eproject.el
@@ -68,19 +68,7 @@
 			(eproject-list-project-files-relative)))))
     (action . (lambda (candidate)
                 (let ((candidate-abs (concat (eproject-root) candidate)))
-                  (message candidate-abs)
                   (find-file candidate-abs))))))
-;(helm-switch-to-buffer (get-buffer-create candidate-abs)))))))
-                ;; (let ((mjm (and helm-current-prefix-arg
-                 ;;                 (intern (helm-comp-read
-                 ;;                          "Major-mode: "
-                 ;;                          helm-buffers-favorite-modes))))
-                 ;;       (buffer (get-buffer-create candidate)))
-                 ;;   (if mjm
-                 ;;       (with-current-buffer buffer (funcall mjm))
-                 ;;     (set-buffer-major-mode buffer))
-                 ;;   (helm-switch-to-buffer buffer))))))
-
 
 (defun helm-eproject ()
   "helps helm to use eproject to find a file"


### PR DESCRIPTION
I've been using eproject and helm for a long time now and lately I've been annoyed with the fact that helm-eproject sources does not show file relative paths for the current project in the helm buffer. 

This has been fixed now.

Possible improvements:
- make it configurable whether to display a file's relative path or its basename? -> helm let's you configure the behaviour for most of its completion buffers, e.g. helm-source-recentf, see helm variable `helm-ff-transformer-show-only-basename`. This would require an additional check in the `action` part of helm-eproject's source definition.
- add tests

**Note**: Change has only be tested on an OSx machine. 
