### PR TITLE
Allow customizing the keyboard binding prefix

### DIFF
--- a/eproject-extras.el
+++ b/eproject-extras.el
@@ -349,11 +349,11 @@ not in a project."
                 (file-name-directory filename)
               default-directory))))))
 
-(define-key eproject-mode-map (kbd "C-c C-f") #'eproject-find-file)
-(define-key eproject-mode-map (kbd "C-c C-b") #'eproject-ibuffer)
-(define-key eproject-mode-map (kbd "C-c b") #'eproject-switch-to-buffer)
-(define-key eproject-mode-map (kbd "C-c 4 b") #'eproject-switch-to-buffer-other-window)
-(define-key eproject-mode-map (kbd "C-c 5 b") #'eproject-switch-to-buffer-other-frame)
+(define-key eproject-mode-map (kbd (concat eproject-keybind-prefix " C-f")) #'eproject-find-file)
+(define-key eproject-mode-map (kbd (concat eproject-keybind-prefix " C-b")) #'eproject-ibuffer)
+(define-key eproject-mode-map (kbd (concat eproject-keybind-prefix " b")) #'eproject-switch-to-buffer)
+(define-key eproject-mode-map (kbd (concat eproject-keybind-prefix " 4 b")) #'eproject-switch-to-buffer-other-window)
+(define-key eproject-mode-map (kbd (concat eproject-keybind-prefix " 5 b")) #'eproject-switch-to-buffer-other-frame)
 
 (provide 'eproject-extras)
 ;;; eproject-extras.el ends here

--- a/eproject.el
+++ b/eproject.el
@@ -221,6 +221,12 @@
   :link '(emacs-library-link :tag "Optional extras" "eproject-extras.el")
   :link '(url-link :tag "Github wiki" "http://wiki.github.com/jrockway/eproject"))
 
+(defcustom eproject-keybind-prefix
+  "C-c"
+  "The keybind prefix for eproject"
+  :type 'string
+  :group 'eproject)
+
 (defvar eproject-root nil
   "A buffer-local variable set to the root of its eproject
   project.  NIL if it isn't in an eproject.  Your code should
@@ -667,7 +673,7 @@ that FILE is an absolute path."
 
 (define-derived-mode dot-eproject-mode emacs-lisp-mode "dot-eproject"
   "Major mode for editing .eproject files."
-  (define-key dot-eproject-mode-map (kbd "C-c C-c") #'eproject-reinitialize-project))
+  (define-key dot-eproject-mode-map (kbd (concat eproject-keybind-prefix " C-c")) #'eproject-reinitialize-project))
 
 ;; introspect sets of projects
 (defun eproject-projects ()


### PR DESCRIPTION
C-c is widely used by many modes. It would be a good idea to allow customizing the keyboard binding prefix to avoid conflict.
