### PR TITLE
Use read-kbd-macro for defining keybindings, because it's not a macro

### DIFF
--- a/eproject-extras.el
+++ b/eproject-extras.el
@@ -349,11 +349,11 @@ not in a project."
                 (file-name-directory filename)
               default-directory))))))
 
-(define-key eproject-mode-map (kbd (concat eproject-keybind-prefix " C-f")) #'eproject-find-file)
-(define-key eproject-mode-map (kbd (concat eproject-keybind-prefix " C-b")) #'eproject-ibuffer)
-(define-key eproject-mode-map (kbd (concat eproject-keybind-prefix " b")) #'eproject-switch-to-buffer)
-(define-key eproject-mode-map (kbd (concat eproject-keybind-prefix " 4 b")) #'eproject-switch-to-buffer-other-window)
-(define-key eproject-mode-map (kbd (concat eproject-keybind-prefix " 5 b")) #'eproject-switch-to-buffer-other-frame)
+(define-key eproject-mode-map (read-kbd-macro (concat eproject-keybind-prefix " C-f")) #'eproject-find-file)
+(define-key eproject-mode-map (read-kbd-macro (concat eproject-keybind-prefix " C-b")) #'eproject-ibuffer)
+(define-key eproject-mode-map (read-kbd-macro (concat eproject-keybind-prefix " b")) #'eproject-switch-to-buffer)
+(define-key eproject-mode-map (read-kbd-macro (concat eproject-keybind-prefix " 4 b")) #'eproject-switch-to-buffer-other-window)
+(define-key eproject-mode-map (read-kbd-macro (concat eproject-keybind-prefix " 5 b")) #'eproject-switch-to-buffer-other-frame)
 
 (provide 'eproject-extras)
 ;;; eproject-extras.el ends here


### PR DESCRIPTION
Using kbd with concat was causing problems for my emacs (23.4.1 from Debian Stable), as best I could tell because kbd is a macro and thus the evaluation order was not as emacs expected.  (I'm not an elisp maven, I could be wrong here.)  As kbd is defined in my emacs as simply (read-kbd-macro keys), I replaced kbd with read-kbd-macro directly and this problem went away.  This behavior of read-kbd-macro is documented for emacs 24 and also works on my laptop running 24.3.1 from Ubuntu LTS.
